### PR TITLE
Corrected assembly name of EditorPlugin template

### DIFF
--- a/DualityEditorPlugin/ProjectTemplate.csproj
+++ b/DualityEditorPlugin/ProjectTemplate.csproj
@@ -19,7 +19,7 @@
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>$safeprojectname$</RootNamespace>
-    <AssemblyName>$safeprojectname$</AssemblyName>
+    <AssemblyName>$safeprojectname$.editor</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>


### PR DESCRIPTION
Duality requires the assembly name to end with .editor in order to be considered an editor plugin